### PR TITLE
Add independent-package notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Laravel Cloud Binaries
 
+> [!NOTE]
+> This is an independent, community package. It is not an official or
+> first-party Laravel package, and is not affiliated with, endorsed by, or
+> sponsored by Laravel or Laravel Cloud. "Laravel" is a trademark of its
+> respective owner.
+
 Pre-built, statically compiled binaries for Linux (arm64/musl). Designed to be installed as a Composer package so that `vendor/bin/` contains ready-to-use tools on Laravel Cloud (or any Linux arm64 environment).
 
 This package includes all the binaries required by [spatie/image-optimizer](https://github.com/spatie/image-optimizer), making it a drop-in solution for image optimization on environments where system packages are not available. Note that [svgo](https://github.com/svg/svgo) is not included as it is a regular npm package and can be installed via `npm install -g svgo`.


### PR DESCRIPTION
Adds the same independence/trademark notice used in [mathiasgrimm/laravel-puff](https://github.com/mathiasgrimm/laravel-puff), so both packages carry identical wording.

```markdown
> [!NOTE]
> This is an independent, community package. It is not an official or
> first-party Laravel package, and is not affiliated with, endorsed by, or
> sponsored by Laravel or Laravel Cloud. "Laravel" is a trademark of its
> respective owner.
```

Matched to laravel-puff on wording, the GitHub `[!NOTE]` callout, and line wrapping. Placed at the top of the README before the description — the same position it occupies there (in laravel-puff it follows the badge block; this repo has no badges, so it sits directly under the H1).

README-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)